### PR TITLE
Change all services to ClusterIP

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: spyder-scan
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.83.3
+    rev: v3.83.7
     hooks:
       - id: trufflehog
         entry: trufflehog git file://. --since-commit HEAD --no-verification --fail

--- a/guidebook/src/supply_chain/README.md
+++ b/guidebook/src/supply_chain/README.md
@@ -19,7 +19,7 @@ pod/rsvp-app-587559dbf4-mbxkl   1/1     Running   0          18h
 
 NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
 service/mongodb    ClusterIP   10.43.220.107   <none>        27017/TCP      25h
-service/rsvp-app   NodePort    10.43.201.79    <none>        80:30135/TCP   25h
+service/rsvp-app   ClusterIP   10.43.201.79    <none>        80/TCP         25h
 
 NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/mongodb    1/1     1            1           25h

--- a/modules/cryptominer.yaml
+++ b/modules/cryptominer.yaml
@@ -39,7 +39,7 @@ metadata:
   labels:
     managed-by: spyderbat-eval
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: jupyter-notebook
   ports:

--- a/modules/supply-chain.yaml
+++ b/modules/supply-chain.yaml
@@ -109,7 +109,7 @@ metadata:
     env: dev
     managed-by: spyderbat-eval
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - port: 80
     targetPort: 5000


### PR DESCRIPTION
This should prevent any open ports from being exposed to the wider network. According to k8s documentation:

> [ClusterIP](https://kubernetes.io/docs/concepts/services-networking/service/#type-clusterip)
>   Exposes the Service on a cluster-internal IP. **Choosing this value makes the Service only reachable from within the cluster.** This is the default that is used if you don't explicitly specify a type for a Service. You can expose the Service to the public internet using an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) or a [Gateway](https://gateway-api.sigs.k8s.io/).
> https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types

All other services did not specify a type, which means they default to ClusterIP. I tested locally to ensure that all services were still reachable with the `access.sh` script.